### PR TITLE
Update entra_id.rb

### DIFF
--- a/lib/omniauth/strategies/entra_id.rb
+++ b/lib/omniauth/strategies/entra_id.rb
@@ -13,7 +13,7 @@ module OmniAuth
 
       DEFAULT_SCOPE    = 'openid profile email'
       COMMON_TENANT_ID = 'common'
-
+      ADFS_TENANT_ID = 'adfs'
       # The tenant_provider must return client_id, client_secret and,
       # optionally, tenant_id and base_url.
       #
@@ -135,9 +135,9 @@ module OmniAuth
 
           # For multi-tenant apps (the 'common' tenant_id) it doesn't make any
           # sense to verify the token issuer, because the value of 'iss' in the
-          # token depends on the 'tid' in the token itself.
+          # token depends on the 'tid' in the token itself. We should also skip for ADFS local instance, as we dont put a valid tenant id in its place, but adfs instead
           #
-          issuer = if options.tenant_id.nil? || options.tenant_id == COMMON_TENANT_ID
+          issuer = if options.tenant_id.nil? || options.tenant_id == COMMON_TENANT_ID || options.tenant_id == ADFS_TENANT_ID
             nil
           else
             "#{options.base_url || BASE_URL}/#{options.tenant_id}/v2.0"


### PR DESCRIPTION
Add support, for on premsis ADFS where teh tenat id has to be set as ADFS, in which case we shouldnt try to verify as we are not in multi tenant mode.